### PR TITLE
Add method for clearing the placeholder text

### DIFF
--- a/EAMTextView/EAMTextView.h
+++ b/EAMTextView/EAMTextView.h
@@ -111,9 +111,4 @@
  */
 @property (nonatomic) NSTimeInterval autoresizingAnimationDuration;
 
-/**
- *  Clears the placeholder text.
- */
-- (void)clearPlaceholder;
-
 @end

--- a/EAMTextView/EAMTextView.m
+++ b/EAMTextView/EAMTextView.m
@@ -98,9 +98,7 @@ static CGFloat const EAMTextViewPlaceholderInset = 8.0f;
 {
     if (![_placeholder isEqualToString:placeholder]) {
         _placeholder = placeholder;
-        if ([self _shouldDrawPlaceholder]) {
-            [self setNeedsDisplay];
-        }
+        [self setNeedsDisplay];
     }
 }
 
@@ -118,12 +116,6 @@ static CGFloat const EAMTextViewPlaceholderInset = 8.0f;
     if ([self _shouldDrawPlaceholder]) {
         [self setNeedsDisplay];
     }
-}
-
-- (void)clearPlaceholder
-{
-    self.placeholder = nil;
-    [self setNeedsDisplay];
 }
 
 - (CGRect)_placeholderRectInRect:(CGRect)rect


### PR DESCRIPTION
I use this to remove the placeholder text when the keyboard will appear.

The main reason for doing this is that I am animating the frame of the text view, making it narrower in order to reveal some other controls in the input bar. As the placeholder text is just a string drawn into a graphics context it gets scaled disproportionately as the text view is resized. Clearing the placeholder text solves this problem.
